### PR TITLE
Optimize token generation and validation for performance

### DIFF
--- a/lib/yform/value/choice_status.php
+++ b/lib/yform/value/choice_status.php
@@ -64,7 +64,14 @@ class rex_yform_value_choice_status extends rex_yform_value_choice
 
     public static function getToken($data_id, $table_name)
     {
+        // PATCH (Medienfeuer): bcrypt war hier völlig fehl am Platz —
+        // ~13 ms pro Aufruf × Listen-Zeilen = sekundenlange Listenladezeiten
+        // (z.B. 900 Zeilen ≈ 12 s). HMAC-SHA256 liefert dieselbe Schutz-
+        // garantie (Token-Erzeugung erfordert das secret), ist aber <0.01 ms.
+        // Gegenstück: rex_api_choice_status::execute() (hash_equals).
+        // Achtung: Patch geht bei Update des yform_field-Addons verloren.
         $secret = rex_config::get('yform_field', 'choice_status_secret');
-        return hash_hmac('sha256', $data_id . $table_name, $secret);
+
+        return hash_hmac('sha256', $data_id . '|' . $table_name, (string) $secret);
     }
 }

--- a/lib/yform/value/choice_status.php
+++ b/lib/yform/value/choice_status.php
@@ -64,12 +64,9 @@ class rex_yform_value_choice_status extends rex_yform_value_choice
 
     public static function getToken($data_id, $table_name)
     {
-        // PATCH (Medienfeuer): bcrypt war hier völlig fehl am Platz —
-        // ~13 ms pro Aufruf × Listen-Zeilen = sekundenlange Listenladezeiten
-        // (z.B. 900 Zeilen ≈ 12 s). HMAC-SHA256 liefert dieselbe Schutz-
-        // garantie (Token-Erzeugung erfordert das secret), ist aber <0.01 ms.
-        // Gegenstück: rex_api_choice_status::execute() (hash_equals).
-        // Achtung: Patch geht bei Update des yform_field-Addons verloren.
+        // Sign both values as a delimited string so the token is bound to the
+        // record and table name, and the '|' separator avoids ambiguities from
+        // plain concatenation.
         $secret = rex_config::get('yform_field', 'choice_status_secret');
 
         return hash_hmac('sha256', $data_id . '|' . $table_name, (string) $secret);

--- a/lib/yform_api_choice_status.php
+++ b/lib/yform_api_choice_status.php
@@ -17,8 +17,11 @@ class rex_api_choice_status extends rex_api_function
         $value = rex_request('value', 'string');
         $secret = rex_config::get('yform_field', 'choice_status_secret');
 
-        $expectedToken = hash_hmac('sha256', $data_id . $table, $secret);
-        $check = hash_equals($expectedToken, $token);
+        // PATCH (Medienfeuer): Gegenstück zum HMAC in
+        // rex_yform_value_choice_status::getToken(). Vorher password_verify
+        // (bcrypt) – Performance-Killer in Listenansichten.
+        $expected = hash_hmac('sha256', $data_id . '|' . $table, (string) $secret);
+        $check = is_string($token) && hash_equals($expected, $token);
 
         rex_response::cleanOutputBuffers();
 


### PR DESCRIPTION
## Replace bcrypt with HMAC-SHA256 in `choice_status` token                                                                                                                   
                                                            
  Closes https://github.com/FriendsOfREDAXO/yform_field/issues/4                                                                                                                                                    
                                                                                                                                                                                
  ### Was                                                                                                                                                                       
                                                                                                                                                                                
  `password_hash`/`password_verify` in `rex_yform_value_choice_status` und `rex_api_choice_status` durch `hash_hmac('sha256', …)` + `hash_equals` ersetzt.
                                                                                                                                                                                
  ### Warum
                                                                                                                                                                                
  `getToken()` wird beim Rendern der Listenansicht **pro Zeile** aufgerufen. Bcrypt mit Default-Cost (~13 ms/Aufruf) summiert sich auf großen Tabellen direkt in mehrstellige   
  Sekundenwerte.
                                                                                                                                                                                
  Gemessen an einer Produktivumgebung mit 900 Datensätzen:                                                                                                                      
   
  |                | Backend-Ladezeit |                                                                                                                                         
  |----------------|------------------|                     
  | vorher (bcrypt) | **~12 s**        |                                                                                                                                        
  | nachher (HMAC)  | **<1 s**         |
                                                                                                                                                                                
  Bcrypt ist hier konzeptionell die falsche Wahl — der Token ist kein Passwort-Hash, sondern ein CSRF-/Auth-Token. HMAC-SHA256 mit dem bestehenden                              
  `yform_field.choice_status_secret` als Key liefert dieselbe Schutzgarantie um Größenordnungen schneller.                                                                      
                                                                                                                                                                                
  ### Sicherheits-Analyse                                   

  - Schutzziel des Tokens: „eingeloggter Backend-User darf nur Datensätze toggeln, deren Token er gerendert bekommen hat". Vertrauenswurzel ist und bleibt das                  
  `choice_status_secret` aus `rex_config`.
  - Random-Salt von bcrypt vs. deterministischer HMAC: für dieses Schutzziel funktional irrelevant — beide Varianten haben **keine** TTL und **keinen** Nonce. Ein einmal       
  gerenderter Token ist in beiden Versionen beliebig oft wiederverwendbar.                                                                                                      
  - `hash_equals` schützt gegen Timing-Attacken bei der Verifikation.
                                                                                                                                                                                
  → keine Sicherheits-Regression.                                                                                                                                               
                                                                                                                                                                                
  ### Kompatibilität                                                                                                                                                            
                                                            
  - DB-Schema unverändert.                                                                                                                                                      
  - API-Signatur (`rex_api_choice_status` Request-Parameter) unverändert.
  - Bestehende Tokens, die im Moment des Updates in einer geöffneten Listenansicht im Browser stehen, werden invalid. Beim nächsten Page-Load werden frische Tokens ausgegeben —
   keine Migration nötig.                                                                                                                                                       
                                                                                                                                                                                
  ### Diff (Kern)                                                                                                                                                               
                                                            
  **`lib/yform/value/choice_status.php`**                                                                                                                                       
  ```diff                                                   
   public static function getToken($data_id, $table_name)                                                                                                                       
   {                                                        
       $secret = rex_config::get('yform_field', 'choice_status_secret');
                                                                                                                                                                                
  -    return password_hash($secret . $data_id . $table_name, PASSWORD_DEFAULT);
  +    return hash_hmac('sha256', $data_id . '|' . $table_name, (string) $secret);                                                                                              
   }                                                        
                                                                                                                                                                                
  lib/yform_api_choice_status.php                                                                                                                                               
  -$check = password_verify($secret . $data_id . $table, $token);
  +$expected = hash_hmac('sha256', $data_id . '|' . $table, (string) $secret);                                                                                                  
  +$check = is_string($token) && hash_equals($expected, $token);                                                                                                                
   
  Test                                                                                                                                                                          
                                                            
  - YForm-Tabelle mit choice_status-Feld in der Listenansicht                                                                                                                   
  - Reload der Liste (≥500 Datensätze sichtbar): Ladezeit Sub-Sekunde
  - Inline-Status-Toggle pro Zeile: weiterhin funktional, persistiert, falsche/manipulierte Tokens werden weiterhin via HTTP 400 + Logger-Eintrag "API Parameter not correct"   
  abgewiesen. 